### PR TITLE
Make Icons Non Responsive

### DIFF
--- a/includes/modules/boxes/bm_card_acceptance.php
+++ b/includes/modules/boxes/bm_card_acceptance.php
@@ -37,7 +37,7 @@
         $output = NULL;
 
         foreach ( explode(';', MODULE_BOXES_CARD_ACCEPTANCE_LOGOS) as $logo ) {
-          $output .= tep_image(DIR_WS_IMAGES . 'card_acceptance/' . basename($logo));
+          $output .= tep_image(DIR_WS_IMAGES . 'card_acceptance/' . basename($logo), null, null, null, null, false);
         }
                    
         ob_start();

--- a/includes/modules/boxes/bm_languages.php
+++ b/includes/modules/boxes/bm_languages.php
@@ -43,7 +43,7 @@
           $languages_string = '';
           reset($lng->catalog_languages);
           while (list($key, $value) = each($lng->catalog_languages)) {
-            $languages_string .= ' <a href="' . tep_href_link($PHP_SELF, tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' . tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name']) . '</a> ';
+            $languages_string .= ' <a href="' . tep_href_link($PHP_SELF, tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' .tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name'], NULL, NULL, NULL, false) . '</a> ';
           }
                   
           ob_start();

--- a/includes/modules/content/navigation/templates/navbar.php
+++ b/includes/modules/content/navigation/templates/navbar.php
@@ -34,7 +34,7 @@
                   echo '<li class="divider"></li>';
                   reset($lng->catalog_languages);
                   while (list($key, $value) = each($lng->catalog_languages)) {
-                    echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' . tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name']) . '</a></li>';
+                    echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' . tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name'], null, null, null, false) . ' ' . $value['name'] . '</a></li>';
                   }
                 }
                 // currencies


### PR DESCRIPTION
Responsive Images take 100% width of their container, which is undesirable in some areas (especially tiny icons).